### PR TITLE
Fix `[Vue warn]: You may have an infinite update loop in a component render function.`

### DIFF
--- a/src/components/field-array.vue
+++ b/src/components/field-array.vue
@@ -127,18 +127,16 @@
     },
     methods: {
       generateSchema(rootValue, schema, index) {
-        if (!schema) {
-          schema = {};
-        }
+        let newSchema = {...schema};
 
         if (typeof this.schema.inputName !== "undefined") {
-          schema.inputName = this.schema.inputName + "[" + index + "]";
+          newSchema.inputName = this.schema.inputName + "[" + index + "]";
         }
 
-        schema.id = this.fieldId + index;
+        newSchema.id = this.fieldId + index;
 
         return {
-          ...schema,
+          ...newSchema,
           set(model, value) {
             Vue.set(rootValue, index, value);
           },


### PR DESCRIPTION
`generateSchema` was mutating state on render causing an infinite loop because of how objects are passed in Javascript, by “copy of a reference”, but the object’s contents are passed by “reference”.