### PR TITLE
Pass on vfg property to child fields.

### DIFF
--- a/src/components/field-array.vue
+++ b/src/components/field-array.vue
@@ -13,6 +13,7 @@
           :moveElementDownButtonLabel="moveElementDownButtonLabel"
           :itemContainerHeader="schema.itemContainerHeader"
           :schema='generateSchema(value, schema.items, index)'
+          :vfg='vfg'
           @moveItemUp="moveElementUp(index)"
           @moveItemDown="moveElementDown(index)"
           @removeItem='removeElement(index)'>
@@ -20,6 +21,7 @@
             :is='getFieldType(schema.items)'
             :model='item'
             :schema='generateSchema(value, schema.items, index)'
+            :vfg='vfg'
             :formOptions='formOptions'
             @model-updated='modelUpdated'/>
         </component>
@@ -29,6 +31,7 @@
           :is='getFieldType(schema.items)'
           :model='item'
           :schema='generateSchema(value, schema.items, index)'
+          :vfg='vfg'
           :formOptions='formOptions'
           @model-updated='modelUpdated'/>
       </span>
@@ -44,6 +47,7 @@
           :moveElementDownButtonLabel="moveElementDownButtonLabel"
           :itemContainerHeader="schema.itemContainerHeader"
           :schema='generateSchema(value, schema.items, index)'
+          :vfg='vfg'
           @moveItemUp="moveElementUp(index)"
           @moveItemDown="moveElementDown(index)"
           @removeItem='removeElement(index)'>
@@ -80,6 +84,7 @@
       :is='getFieldType(schema.items)'
       :model='newItem'
       :schema='generateSchema(this, schema.items, "newItem")'
+      :vfg='vfg'
       :formOptions='formOptions'
       @model-updated='emptyComponentModelUpdated'/>
     <input v-if="!schema.hideAddButton" type="button" :value="newElementButtonLabel" :class="schema.newElementButtonLabelClasses" @click="newElement"/>


### PR DESCRIPTION
In our application, we use the auto-added 'vfg' property that
vue-form-generator adds onto each field to get access to the main schema
for certain context-related data that we require. This commit sets that
field on all children field in vfg-array-field, previously it was not
set and thus undefined.


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:
